### PR TITLE
Update cell-lines.yaml

### DIFF
--- a/cell-lines/1.1.0/cell-lines.yaml
+++ b/cell-lines/1.1.0/cell-lines.yaml
@@ -28,6 +28,25 @@ columns:
             - MCF7
             - A549
 
+  - name: characteristics[disease]
+    description: Disease state of the original tissue from which the cell line was established
+    requirement: required
+    allow_not_applicable: true
+    allow_not_available: true
+    validators:
+      - validator_name: ontology
+        params:
+          ontologies:
+            - mondo
+            - efo
+            - doid
+          error_level: warning
+          description: The disease should be a valid MONDO, EFO, or DOID ontology term. Use 'normal' if applicable.
+          examples:
+            - cervical adenocarcinoma
+            - chronic myelogenous leukemia
+            - normal
+
   - name: characteristics[cellosaurus accession]
     description: Cellosaurus accession number for the cell line
     requirement: required


### PR DESCRIPTION
add disease to cell-lines template enforcement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced disease state field to cell line definitions. This required field enables users to document and specify disease characteristics associated with the original tissue sources. The field supports standardized disease ontologies including MONDO, EFO, and DOID, with built-in allowances for marking values as not applicable or not available when specific disease information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->