### PR TITLE
Refactoring yaml to have more nested structure

### DIFF
--- a/single-cell/1.0.0/single-cell.yaml
+++ b/single-cell/1.0.0/single-cell.yaml
@@ -4,423 +4,549 @@ version: 1.0.0
 extends: ms-proteomics
 usable_alone: false
 layer: experiment
+
 columns:
-  # Core columns inherited from ms-proteomics/base: organism, organism part, cell type, biological replicate
-  # Disease and organism-specific columns come from sample templates (human, vertebrates, etc.)
 
-  # ==========================================================================
-  # REQUIRED COLUMNS (per Nature Methods SCP guidelines)
-  # ==========================================================================
+  - name: sample
+    children:
 
-  - name: comment[sample type]
-    description: Classification of the sample - distinguishes single cells from carriers, references, and controls. Critical for proper data analysis.
-    requirement: required
-    allow_not_applicable: false
-    allow_not_available: false
-    validators:
-      - validator_name: values
-        params:
-          values:
-            - single cell
-            - carrier
-            - reference
-            - empty
-            - negative control
-            - bulk control
-            - not applicable
-          error_level: error
-          description: Sample type classification per SCP guidelines
+      - name: identifier
+        description: Unique identifier for each single cell within the experiment. Required per SCP guidelines for tracking cells through analysis.
+        requirement: required
+        allow_not_applicable: true
+        allow_not_available: false
+        validators:
+          - validator_name: pattern
+            params:
+              pattern: ^[A-Za-z0-9_.-]+$|^carrier$|^reference$|^empty$|^not applicable$
+              description: Cell identifier (alphanumeric with underscores, hyphens, dots)
+              examples:
+                - cell_001
+                - SC_A1
+                - well_B3
+                - barcode_ATCGATCG
+                - carrier
+                - reference
 
-  - name: characteristics[single cell isolation method]
-    description: Method used to isolate single cells (FACS, cellenONE, LCM, etc.)
-    requirement: required
-    allow_not_applicable: true
-    allow_not_available: false
-    validators:
-      - validator_name: values
-        params:
-          values:
-            - FACS
-            - cellenONE
-            - CellenONE
-            - microfluidics
-            - laser capture microdissection
-            - LCM
-            - manual picking
-            - nanoPOTS
-            - droplet microfluidics
-            - acoustic droplet ejection
-            - not applicable
-          error_level: warning
-          description: Single cell isolation method
+      - name: type
+        description: Classification of the sample - distinguishes single cells from carriers, references, and controls.
+        requirement: required
+        allow_not_applicable: false
+        allow_not_available: false
+        validators:
+          - validator_name: values
+            params:
+              values:
+                - single cell
+                - carrier
+                - reference
+                - empty
+                - negative control
+                - bulk control
+                - not applicable
+              error_level: error
 
-  - name: characteristics[cell identifier]
-    description: Unique identifier for each single cell within the experiment. Required per SCP guidelines for tracking cells through analysis.
-    requirement: required
-    allow_not_applicable: true
-    allow_not_available: false
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^[A-Za-z0-9_.-]+$|^carrier$|^reference$|^empty$|^not applicable$
-          description: Cell identifier (alphanumeric with underscores, hyphens, dots)
-          examples:
-            - cell_001
-            - SC_A1
-            - well_B3
-            - barcode_ATCGATCG
-            - carrier
-            - reference
+  - name: instrument
+    children:
 
-  # ==========================================================================
-  # RECOMMENDED COLUMNS (per Nature Methods SCP guidelines)
-  # ==========================================================================
+      - name: Isolation
+        children:
 
-  - name: characteristics[individual]
-    description: Unique identifier for the individual organism (human donor, mouse, etc.). Important for studies with multiple individuals to track biological variability.
-    requirement: recommended
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^[A-Za-z0-9_-]+$|^not available$|^not applicable$
-          description: Individual organism identifier
-          examples:
-            - patient_001
-            - mouse_A
-            - animal_12
-            - donor_A
+          - name: method
+            description: Method used to isolate single cells
+            requirement: required
+            allow_not_applicable: true
+            allow_not_available: false
+            validators:
+              - validator_name: values
+                params:
+                  values:
+                    - FACS
+                    - cellenONE
+                    - microfluidics
+                    - LCM
+                    - nanoPOTS
+                    - manual picking
+                    - droplet microfluidics
+                    - acoustic droplet ejection
+                    - not applicable
+                  error_level: warning
 
-  - name: comment[sample preparation batch]
-    description: Batch identifier for sample preparation (plate, chip, processing batch). Critical for batch effect correction.
-    requirement: recommended
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^.+$
-          description: Sample preparation batch identifier
-          examples:
-            - plate1
-            - plate2
-            - chip_A
-            - batch_20220601
+            subschemas:
 
-  - name: comment[cells per well]
-    description: Number of cells per well/reaction. Use 1 for true single cells, higher numbers for small pools.
-    requirement: recommended
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^\d+$|^not applicable$|^not available$
-          description: Number of cells
-          examples:
-            - 1
-            - 5
-            - 10
-            - 100
+              FACS:
+                children:
+                  - name: model
+                    description: FACS instrument model
+                    requirement: required
 
-  - name: characteristics[developmental stage]
-    description: Developmental stage of the organism at sample collection
-    requirement: recommended
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: ontology
-        params:
-          ontologies:
-            - efo
-            - hsapdv
-            - mmusdv
-            - uberon
-          error_level: warning
-          description: Developmental stage should be a valid ontology term
-          examples:
-            - adult
-            - embryonic stage
-            - fetal stage
-            - neonate
+                  - name: forward scatter
+                    description: Forward scatter (FSC) value from flow cytometry - proxy for cell size
+                    requirement: optional
+                    allow_not_applicable: true
+                    allow_not_available: true
+                    validators:
+                      - validator_name: pattern
+                        params:
+                          pattern: ^[\d.]+$|^not available$|^not applicable$
+                          description: FSC value (numeric)
+                          examples:
+                            - 316.0
+                            - 250
+                            - not applicable
 
-  # ==========================================================================
-  # OPTIONAL COLUMNS - Flow Cytometry Data (per Nature Methods guidelines)
-  # ==========================================================================
+                  - name: side scatter
+                    description: Side scatter (SSC) value from flow cytometry - proxy for cell granularity/complexity
+                    requirement: optional
+                    allow_not_applicable: true
+                    allow_not_available: true
+                    validators:
+                      - validator_name: pattern
+                        params:
+                          pattern: ^[\d.]+$|^not available$|^not applicable$
+                          description: SSC value (numeric)
+                          examples:
+                            - 301.0
+                            - 184
+                            - not applicable
 
-  - name: characteristics[forward scatter]
-    description: Forward scatter (FSC) value from flow cytometry - proxy for cell size
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^[\d.]+$|^not available$|^not applicable$
-          description: FSC value (numeric)
-          examples:
-            - 316.0
-            - 250
-            - not applicable
+                  - name: sorting marker
+                    description: Markers used for cell sorting/selection with optional intensity values
+                    requirement: optional
+                    allow_not_applicable: true
+                    allow_not_available: true
+                    validators:
+                      - validator_name: pattern
+                        params:
+                          pattern: ^.+$
+                          description: Sorting marker(s) and optional intensity
+                          examples:
+                            - CD45+
+                            - GFP+
+                            - CD3+CD4+
+                            - CD34:APC-Cy7-A=276.0
+                            - PI-
 
-  - name: characteristics[side scatter]
-    description: Side scatter (SSC) value from flow cytometry - proxy for cell granularity/complexity
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^[\d.]+$|^not available$|^not applicable$
-          description: SSC value (numeric)
-          examples:
-            - 301.0
-            - 184
-            - not applicable
+                  - name: nozzle_size
+                    description: Nozzle size (µm)
+                    requirement: optional
 
-  - name: characteristics[sorting marker]
-    description: Markers used for cell sorting/selection with optional intensity values
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^.+$
-          description: Sorting marker(s) and optional intensity
-          examples:
-            - CD45+
-            - GFP+
-            - CD3+CD4+
-            - CD34:APC-Cy7-A=276.0
-            - PI-
+                  - name: sorting_mode
+                    description: Sorting mode (single-cell, index, bulk)
+                    requirement: optional
 
-  # ==========================================================================
-  # OPTIONAL COLUMNS - Cell State and Quality
-  # ==========================================================================
+              microfluidics:
+                children:
+                  - name: chip type
+                    description: Microfluidic chip type
+                    requirement: required
 
-  - name: characteristics[cell viability]
-    description: Viability status of the cell at isolation
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: values
-        params:
-          values:
-            - live
-            - viable
-            - dead
-            - unknown
-            - not available
-            - not applicable
-          error_level: warning
-          description: Cell viability status
+                  - name: manufacturer
+                    description: Device manufacturer
+                    requirement: optional
 
-  - name: characteristics[cell cycle phase]
-    description: Cell cycle phase if determined (e.g., by FACS or computational inference)
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: values
-        params:
-          values:
-            - G1
-            - S
-            - G2
-            - G2/M
-            - M
-            - G0
-            - not determined
-            - not available
-            - not applicable
-          error_level: warning
-          description: Cell cycle phase
+              LCM:
+                children:
+                  - name: microscope model
+                    description: LCM microscope model
+                    requirement: required
 
-  - name: characteristics[cell diameter]
-    description: Physical diameter of the isolated cell if measured (in micrometers)
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^[\d.]+ ?um$|^[\d.]+ ?μm$|^not available$|^not applicable$
-          description: Cell diameter with unit
-          examples:
-            - 15 um
-            - 20.5 um
-            - 12 μm
+              nanoPOTS:
+                children:
+                  - name: chip version
+                    description: nanoPOTS chip version
+                    requirement: optional
+        
+          - name: batch
+            description: Isolation batch identifier
+            requirement: optional
+            allow_not_applicable: true
+            allow_not_available: true
+            validators:
+              - validator_name: pattern
+                params:
+                  pattern: ^.+$
+                  description: Isolation batch identifier
+                  examples:
+                    - IS_batch_1
+                    - IS_batch_2
+                    - column_A
 
-  - name: comment[single cell quality]
-    description: Quality assessment of the single cell preparation (pass/fail based on QC criteria)
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: values
-        params:
-          values:
-            - pass
-            - fail
-            - OK
-            - not OK
-            - not available
-            - not applicable
-          error_level: warning
-          description: Single cell quality assessment
+          - name: acquisition date
+            description: Date and time of Isolation data acquisition (ISO 8601 format recommended)
+            requirement: optional
+            allow_not_applicable: true
+            allow_not_available: true
+            validators:
+              - validator_name: pattern
+                params:
+                  pattern: ^.+$
+                  description: Acquisition date/time
+                  examples:
+                    - 2022-06-01_18:28:37
+                    - 2022-06-01
+                    - 20220601
 
-  # ==========================================================================
-  # OPTIONAL COLUMNS - Model Organisms
-  # ==========================================================================
+      - name: MS
+        children:
+          - name: model
+            description: Mass spectrometer instrument model used
+            requirement: required
+            cardinality: multiple
+            allow_not_applicable: false
+            allow_not_available: false
+            validators:
+              - validator_name: ontology
+                params:
+                  ontologies:
+                    - ms
+                  error_level: error
 
-  - name: characteristics[genotype]
-    description: Genotype of the organism (especially for model organisms)
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^.+$
-          description: Genotype notation following standard conventions
-          examples:
-            - wild type genotype
-            - Pitx2-/-
-            - GFP+
-            - daf-2(e1370)
+          - name: acquisition method
+            description: Mass spectrometry acquisition method
+            requirement: required
+            allow_not_applicable: false
+            allow_not_available: false
+            validators:
+              - validator_name: ontology
+                params:
+                  ontologies:
+                    - pride
+                  error_level: error
 
-  - name: characteristics[strain]
-    description: Strain or genetic background of model organisms
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^.+$
-          description: Strain name
-          examples:
-            - C57BL/6
-            - BALB/c
-            - CD1
-            - Sprague-Dawley
+          - name: batch
+            description: MS batch identifier
+            requirement: optional
+            allow_not_applicable: true
+            allow_not_available: true
+            validators:
+              - validator_name: pattern
+                params:
+                  pattern: ^.+$
+                  description: MS batch identifier
+                  examples:
+                    - MS_batch_1
+                    - MS_batch_2
+                    - column_A
 
-  # ==========================================================================
-  # OPTIONAL COLUMNS - Carrier and Multiplexing (for SCoPE-MS type methods)
-  # ==========================================================================
+          - name: acquisition date
+            description: Date and time of MS data acquisition (ISO 8601 format recommended)
+            requirement: optional
+            allow_not_applicable: true
+            allow_not_available: true
+            validators:
+              - validator_name: pattern
+                params:
+                  pattern: ^.+$
+                  description: Acquisition date/time
+                  examples:
+                    - 2022-06-01_18:28:37
+                    - 2022-06-01
+                    - 20220601
 
-  - name: comment[carrier proteome]
-    description: Description of carrier proteome used in carrier-assisted SCP methods (e.g., "200x HeLa carrier")
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^.+$
-          description: Carrier proteome description
-          examples:
-            - 200x HeLa carrier
-            - 100 ng bovine serum albumin
-            - no carrier
-            - not applicable
+      - name: LC
+        children:
+          - name: model
+            description: Liquid chromatography instrument model used
+            requirement: required
+            cardinality: multiple
+            allow_not_applicable: false
+            allow_not_available: false
+            validators:
+              - validator_name: ontology
+                params:
+                  ontologies:
+                    - lc
+                  error_level: error
 
-  - name: comment[carrier channel]
-    description: TMT/iTRAQ channel used for carrier proteome
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^TMT\d+[NC]?$|^iTRAQ\d+$|^not applicable$|^-$
-          description: TMT/iTRAQ channel for carrier
-          examples:
-            - TMT131C
-            - TMT126
-            - not applicable
+          - name: batch
+            description: LC batch identifier
+            requirement: optional
+            allow_not_applicable: true
+            allow_not_available: true
+            validators:
+              - validator_name: pattern
+                params:
+                  pattern: ^.+$
+                  description: LC batch identifier
+                  examples:
+                    - LC1
+                    - LC2
+                    - column_A
 
-  - name: comment[reference channel]
-    description: TMT/iTRAQ channel used for reference/booster sample
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^TMT\d+[NC]?$|^iTRAQ\d+$|^not applicable$|^-$
-          description: TMT/iTRAQ channel for reference
-          examples:
-            - TMT127N
-            - TMT134N
-            - not applicable
+          - name: acquisition date
+            description: Date and time of LC data acquisition (ISO 8601 format recommended)
+            requirement: optional
+            allow_not_applicable: true
+            allow_not_available: true
+            validators:
+              - validator_name: pattern
+                params:
+                  pattern: ^.+$
+                  description: Acquisition date/time
+                  examples:
+                    - 2022-06-01_18:28:37
+                    - 2022-06-01
+                    - 20220601
 
-  # ==========================================================================
-  # OPTIONAL COLUMNS - Batch and Technical Tracking
-  # ==========================================================================
 
-  - name: comment[LC batch]
-    description: Liquid chromatography batch identifier for batch effect tracking
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^.+$
-          description: LC batch identifier
-          examples:
-            - LC1
-            - LC2
-            - column_A
 
-  - name: comment[acquisition date]
-    description: Date and time of MS data acquisition (ISO 8601 format recommended)
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^.+$
-          description: Acquisition date/time
-          examples:
-            - 2022-06-01_18:28:37
-            - 2022-06-01
-            - 20220601
 
-  # ==========================================================================
-  # OPTIONAL COLUMNS - Spatial Information
-  # ==========================================================================
 
-  - name: comment[spatial coordinates]
-    description: X,Y coordinates if cells were isolated from a spatial context (e.g., LCM from tissue)
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^X=[\d.]+;Y=[\d.]+$|^not applicable$|^not available$
-          description: Spatial coordinates
-          examples:
-            - X=100;Y=250
-            - X=50.5;Y=120.3
-            - not applicable
 
-  - name: comment[tissue section]
-    description: Tissue section identifier for spatially resolved single-cell proteomics
-    requirement: optional
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: pattern
-        params:
-          pattern: ^.+$
-          description: Tissue section identifier
-          examples:
-            - section_001
-            - slide_A_section_3
+
+
+
+  # # ==========================================================================
+  # # RECOMMENDED COLUMNS (per Nature Methods SCP guidelines)
+  # # ==========================================================================
+
+  # - name: characteristics[individual]
+  #   description: Unique identifier for the individual organism (human donor, mouse, etc.). Important for studies with multiple individuals to track biological variability.
+  #   requirement: recommended
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: pattern
+  #       params:
+  #         pattern: ^[A-Za-z0-9_-]+$|^not available$|^not applicable$
+  #         description: Individual organism identifier
+  #         examples:
+  #           - patient_001
+  #           - mouse_A
+  #           - animal_12
+  #           - donor_A
+
+
+  # - name: comment[cells per well]
+  #   description: Number of cells per well/reaction. Use 1 for true single cells, higher numbers for small pools.
+  #   requirement: recommended
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: pattern
+  #       params:
+  #         pattern: ^\d+$|^not applicable$|^not available$
+  #         description: Number of cells
+  #         examples:
+  #           - 1
+  #           - 5
+  #           - 10
+  #           - 100
+
+  # - name: characteristics[developmental stage]
+  #   description: Developmental stage of the organism at sample collection
+  #   requirement: recommended
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: ontology
+  #       params:
+  #         ontologies:
+  #           - efo
+  #           - hsapdv
+  #           - mmusdv
+  #           - uberon
+  #         error_level: warning
+  #         description: Developmental stage should be a valid ontology term
+  #         examples:
+  #           - adult
+  #           - embryonic stage
+  #           - fetal stage
+  #           - neonate
+
+  # # ==========================================================================
+  # # OPTIONAL COLUMNS - Cell State and Quality
+  # # ==========================================================================
+
+  # - name: characteristics[cell viability]
+  #   description: Viability status of the cell at isolation
+  #   requirement: optional
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: values
+  #       params:
+  #         values:
+  #           - live
+  #           - viable
+  #           - dead
+  #           - unknown
+  #           - not available
+  #           - not applicable
+  #         error_level: warning
+  #         description: Cell viability status
+
+  # - name: characteristics[cell cycle phase]
+  #   description: Cell cycle phase if determined (e.g., by FACS or computational inference)
+  #   requirement: optional
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: values
+  #       params:
+  #         values:
+  #           - G1
+  #           - S
+  #           - G2
+  #           - G2/M
+  #           - M
+  #           - G0
+  #           - not determined
+  #           - not available
+  #           - not applicable
+  #         error_level: warning
+  #         description: Cell cycle phase
+
+  # - name: characteristics[cell diameter]
+  #   description: Physical diameter of the isolated cell if measured (in micrometers)
+  #   requirement: optional
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: pattern
+  #       params:
+  #         pattern: ^[\d.]+ ?um$|^[\d.]+ ?μm$|^not available$|^not applicable$
+  #         description: Cell diameter with unit
+  #         examples:
+  #           - 15 um
+  #           - 20.5 um
+  #           - 12 μm
+
+  # - name: comment[single cell quality]
+  #   description: Quality assessment of the single cell preparation (pass/fail based on QC criteria)
+  #   requirement: optional
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: values
+  #       params:
+  #         values:
+  #           - pass
+  #           - fail
+  #           - OK
+  #           - not OK
+  #           - not available
+  #           - not applicable
+  #         error_level: warning
+  #         description: Single cell quality assessment
+
+  # # ==========================================================================
+  # # OPTIONAL COLUMNS - Model Organisms
+  # # ==========================================================================
+
+  # - name: characteristics[genotype]
+  #   description: Genotype of the organism (especially for model organisms)
+  #   requirement: optional
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: pattern
+  #       params:
+  #         pattern: ^.+$
+  #         description: Genotype notation following standard conventions
+  #         examples:
+  #           - wild type genotype
+  #           - Pitx2-/-
+  #           - GFP+
+  #           - daf-2(e1370)
+
+  # - name: characteristics[strain]
+  #   description: Strain or genetic background of model organisms
+  #   requirement: optional
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: pattern
+  #       params:
+  #         pattern: ^.+$
+  #         description: Strain name
+  #         examples:
+  #           - C57BL/6
+  #           - BALB/c
+  #           - CD1
+  #           - Sprague-Dawley
+
+  # # ==========================================================================
+  # # OPTIONAL COLUMNS - Carrier and Multiplexing (for SCoPE-MS type methods)
+  # # ==========================================================================
+
+  # - name: comment[carrier proteome]
+  #   description: Description of carrier proteome used in carrier-assisted SCP methods (e.g., "200x HeLa carrier")
+  #   requirement: optional
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: pattern
+  #       params:
+  #         pattern: ^.+$
+  #         description: Carrier proteome description
+  #         examples:
+  #           - 200x HeLa carrier
+  #           - 100 ng bovine serum albumin
+  #           - no carrier
+  #           - not applicable
+
+  # - name: comment[carrier channel]
+  #   description: TMT/iTRAQ channel used for carrier proteome
+  #   requirement: optional
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: pattern
+  #       params:
+  #         pattern: ^TMT\d+[NC]?$|^iTRAQ\d+$|^not applicable$|^-$
+  #         description: TMT/iTRAQ channel for carrier
+  #         examples:
+  #           - TMT131C
+  #           - TMT126
+  #           - not applicable
+
+  # - name: comment[reference channel]
+  #   description: TMT/iTRAQ channel used for reference/booster sample
+  #   requirement: optional
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: pattern
+  #       params:
+  #         pattern: ^TMT\d+[NC]?$|^iTRAQ\d+$|^not applicable$|^-$
+  #         description: TMT/iTRAQ channel for reference
+  #         examples:
+  #           - TMT127N
+  #           - TMT134N
+  #           - not applicable
+
+
+  # # ==========================================================================
+  # # OPTIONAL COLUMNS - Spatial Information
+  # # ==========================================================================
+
+  # - name: spatial[coordinates]
+  #   description: X,Y coordinates if cells were isolated from a spatial context (e.g., LCM from tissue)
+  #   requirement: optional
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: pattern
+  #       params:
+  #         pattern: ^X=[\d.]+;Y=[\d.]+$|^not applicable$|^not available$
+  #         description: Spatial coordinates
+  #         examples:
+  #           - X=100;Y=250
+  #           - X=50.5;Y=120.3
+  #           - not applicable
+
+  # - name: spatial[tissue section]
+  #   description: Tissue section identifier for spatially resolved single-cell proteomics
+  #   requirement: optional
+  #   allow_not_applicable: true
+  #   allow_not_available: true
+  #   validators:
+  #     - validator_name: pattern
+  #       params:
+  #         pattern: ^.+$
+  #         description: Tissue section identifier
+  #         examples:
+  #           - section_001
+  #           - slide_A_section_3


### PR DESCRIPTION
I refactored the yaml to have a more nested branching structure. I think the metadata should be grouped into distinct categories. I particularly wanted to minimize the use of the comments category since it's unstructured. 
 Ex. instrument[LC][batch] vs previously it was comment[LC batch]
 
 Also I think this could be applicable to all the yaml templates, not just the single-cell template.


Let me know of what you think.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restructured sample metadata into a hierarchical schema with organized sample and instrument sections
  * Added validation for sample types, isolation methods, and instrument specifications (MS, LC)
  * Introduced explicit metadata fields for sample identifiers and instrument modalities including FACS, microfluidics, LCM, and nanoPOTS

* **Improvements**
  * Enhanced metadata organization with enumerated allowed values for better data consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->