### PR TITLE
Disease ontology term has been changed from disease EFO to MONDO

### DIFF
--- a/cell-lines/1.1.0/cell-lines.yaml
+++ b/cell-lines/1.1.0/cell-lines.yaml
@@ -56,7 +56,7 @@ columns:
             - A549
 
   - name: characteristics[disease]
-    ontology_accession: EFO:0000408
+    ontology_accession: MONDO:0000001
     description: Disease state of the donor tissue from which the cell line was established
     requirement: required
 

--- a/human/1.1.0/human.yaml
+++ b/human/1.1.0/human.yaml
@@ -35,7 +35,7 @@ mutually_exclusive_with:
   - plants
 columns:
   - name: characteristics[disease]
-    ontology_accession: EFO:0000408
+    ontology_accession: MONDO:0000001
     requirement: required
 
   - name: characteristics[ancestry category]

--- a/invertebrates/1.1.0/invertebrates.yaml
+++ b/invertebrates/1.1.0/invertebrates.yaml
@@ -31,7 +31,7 @@ mutually_exclusive_with:
   - plants
 columns:
   - name: characteristics[disease]
-    ontology_accession: EFO:0000408
+    ontology_accession: MONDO:0000001
     requirement: required
 
   - name: characteristics[developmental stage]

--- a/plants/1.1.0/plants.yaml
+++ b/plants/1.1.0/plants.yaml
@@ -50,7 +50,7 @@ columns:
             - seed
 
   - name: characteristics[disease]
-    ontology_accession: EFO:0000408
+    ontology_accession: MONDO:0000001
     requirement: required
 
   - name: characteristics[developmental stage]

--- a/sample-metadata/1.0.0/sample-metadata.yaml
+++ b/sample-metadata/1.0.0/sample-metadata.yaml
@@ -161,7 +161,7 @@ columns:
             - buffer control
 
   - name: characteristics[disease]
-    ontology_accession: EFO:0000408
+    ontology_accession: MONDO:0000001
     description: Disease state of the sample
     requirement: recommended
     allow_not_applicable: true

--- a/sdrf-template.schema.json
+++ b/sdrf-template.schema.json
@@ -194,7 +194,7 @@
           "type": "string",
           "description": "Ontology/CV term accession for this column (e.g., PRIDE, MS, EFO).",
           "pattern": "^[A-Z]+:[A-Za-z0-9]+$",
-          "examples": ["PRIDE:0000623", "MS:1000031", "EFO:0000408"]
+          "examples": ["PRIDE:0000623", "MS:1000031", "MONDO:0000001"]
         },
         "description": {
           "type": "string",

--- a/vertebrates/1.1.0/vertebrates.yaml
+++ b/vertebrates/1.1.0/vertebrates.yaml
@@ -32,7 +32,7 @@ mutually_exclusive_with:
   - plants
 columns:
   - name: characteristics[disease]
-    ontology_accession: EFO:0000408
+    ontology_accession: MONDO:0000001
     requirement: required
 
   - name: characteristics[developmental stage]


### PR DESCRIPTION
This pull request updates the ontology accession used for the `characteristics[disease]` field across multiple schema and metadata files. The accession is changed from the EFO (Experimental Factor Ontology) term `EFO:0000408` to the MONDO (Mondo Disease Ontology) term `MONDO:0000001`. This ensures consistency and alignment with the MONDO ontology for disease annotation throughout the project.

Key changes by theme:

Ontology accession updates for disease characteristics:

* Updated the `ontology_accession` for `characteristics[disease]` from `EFO:0000408` to `MONDO:0000001` in the following files: `cell-lines.yaml`, `human.yaml`, `invertebrates.yaml`, `plants.yaml`, `sample-metadata.yaml`, and `vertebrates.yaml`. [[1]](diffhunk://#diff-5cae3307a7b3a4f3056538fb2107d1e8d3ab20961cfc21184f1c1ef052b888b5L59-R59) [[2]](diffhunk://#diff-f48d893a6c3d61f5b3de95b622dd4c4584db250347839c6daf75a62849767d78L38-R38) [[3]](diffhunk://#diff-4e9aaefeac5493121b876a9e78e19836704698f8a5aaac0341714cf561f1438fL34-R34) [[4]](diffhunk://#diff-64ac3111b731352c06b8a5a380868ece57428a633ace00b72e6fd78c034b7d75L53-R53) [[5]](diffhunk://#diff-b1f6a8f2eeb3c72b60cc48113abd0f5b028eeaa6f376fe2dec2ec61aab9b0336L164-R164) [[6]](diffhunk://#diff-24afdc36402cfe69ec89e9b3adec8fa85b93594504d2e3263e09b327d64c86d2L35-R35)

Schema example update:

* Changed the example value for ontology accessions in `sdrf-template.schema.json` from `EFO:0000408` to `MONDO:0000001` to match the updated standard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated disease characteristic ontology references across organism-specific templates to use a standardized ontology mapping, ensuring consistency in disease classification across all metadata templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->