### PR TITLE
Add README badges and llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Versioned templates and validation rules for SDRF-Proteomics.
 
+[![Validate Templates](https://github.com/bigbio/sdrf-templates/actions/workflows/validate-templates.yml/badge.svg?branch=main)](https://github.com/bigbio/sdrf-templates/actions/workflows/validate-templates.yml)
+[![Generate Manifest](https://github.com/bigbio/sdrf-templates/actions/workflows/generate-manifest.yml/badge.svg?branch=main)](https://github.com/bigbio/sdrf-templates/actions/workflows/generate-manifest.yml)
+[![License: MIT](https://img.shields.io/github/license/bigbio/sdrf-templates)](https://github.com/bigbio/sdrf-templates/blob/main/LICENSE)
+
+## Overview
+
+This repository stores versioned SDRF template definitions as YAML files. These templates are
+used by the SDRF specification and validation tooling to define required columns, optional
+columns, inheritance rules, and lightweight validation constraints for different experiment
+types and sample metadata layers.
+
+The repository is intentionally data-driven:
+
+- Each template lives in its own versioned directory.
+- `templates.yaml` provides the generated manifest of all known templates.
+- Template inheritance is declared with `extends`.
+- Validation CI checks YAML structure and manifest generation.
+
 ## Structure
 
 ```
@@ -12,7 +30,7 @@ Versioned templates and validation rules for SDRF-Proteomics.
 
 ## Manifest
 
-The `templates.yaml` manifest is auto-generated on merge to master. It contains:
+The `templates.yaml` manifest is auto-generated on merge to `main`. It contains:
 - All available templates
 - Latest version for each template
 - Version history
@@ -66,14 +84,22 @@ Templates use an `extends` field to inherit columns from parent templates:
 - `lc-ms-metabolomics` extends `ms-metabolomics` - LC-MS metabolomics columns
 - `gc-ms-metabolomics` extends `ms-metabolomics` - GC-MS metabolomics columns
 
+In practice, downstream tools should resolve parent templates transitively. Submitters normally
+declare the most specific leaf templates rather than repeating all inherited parents.
+
 ## Adding a New Version
 
 1. Create a new version directory: `{template-name}/{new-version}/`
 2. Add `{template-name}.yaml` with updated `version` field
-3. Submit PR to master
+3. Submit a PR to the active development branch
 4. Manifest will auto-update on merge
 
 ## Repositories Using This
 
 - [proteomics-metadata-standard](https://github.com/bigbio/proteomics-sample-metadata) - Specification
 - [sdrf-pipelines](https://github.com/bigbio/sdrf-pipelines) - Validator
+
+## For LLMs
+
+The repository now also includes [`llms.txt`](./llms.txt), a lightweight index of the files and
+URLs that are most useful for LLM-assisted tooling and repository navigation.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Versioned templates and validation rules for SDRF-Proteomics.
 
 [![Validate Templates](https://github.com/bigbio/sdrf-templates/actions/workflows/validate-templates.yml/badge.svg?branch=main)](https://github.com/bigbio/sdrf-templates/actions/workflows/validate-templates.yml)
 [![Generate Manifest](https://github.com/bigbio/sdrf-templates/actions/workflows/generate-manifest.yml/badge.svg?branch=main)](https://github.com/bigbio/sdrf-templates/actions/workflows/generate-manifest.yml)
-[![License: MIT](https://img.shields.io/github/license/bigbio/sdrf-templates)](https://github.com/bigbio/sdrf-templates/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/bigbio/sdrf-templates)](https://github.com/bigbio/sdrf-templates/blob/main/LICENSE)
 
 ## Overview
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,47 @@
+# SDRF Templates
+
+> Versioned SDRF template definitions for proteomics and related omics, including inheritance rules, column metadata, and the generated manifest used by downstream tooling.
+
+Use this repository when you need the canonical YAML template definitions for SDRF sample
+metadata and acquisition metadata. Start with the README for repository structure, then consult
+the generated manifest and the specific template YAML files you need. Template inheritance is
+important: most concrete templates extend shared layers such as `base` and `sample-metadata`.
+
+When interpreting `comment[sdrf template]`, prefer the most specific leaf templates instead of
+repeating every inherited parent. Downstream validators should resolve inheritance transitively.
+
+## Core files
+
+- [README](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/README.md): Repository overview, structure, manifest usage, and inheritance model.
+- [Manifest](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/templates.yaml): Generated index of all templates, versions, and inheritance metadata.
+- [Schema](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/sdrf-template.schema.json): JSON schema describing the YAML template structure.
+- [Manifest generator](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/scripts/generate_manifest.py): Script that discovers templates and regenerates `templates.yaml`.
+
+## Shared template layers
+
+- [base](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/base/1.1.0/base.yaml): Core SDRF infrastructure columns such as source name, assay name, technology type, and template declarations.
+- [sample-metadata](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/sample-metadata/1.0.0/sample-metadata.yaml): Shared biological sample metadata layer used by organism and technology templates.
+- [clinical-metadata](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/clinical-metadata/1.0.0/clinical-metadata.yaml): Shared clinical annotation layer for treatment, demographics, and provenance.
+- [oncology-metadata](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/oncology-metadata/1.0.0/oncology-metadata.yaml): Cancer-focused extension of the clinical layer.
+
+## Technology templates
+
+- [ms-proteomics](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/ms-proteomics/1.1.0/ms-proteomics.yaml): Mass-spectrometry proteomics template.
+- [dia-acquisition](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/dia-acquisition/1.1.0/dia-acquisition.yaml): DIA-specific extension of `ms-proteomics`.
+- [affinity-proteomics](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/affinity-proteomics/1.0.0/affinity-proteomics.yaml): Affinity assay template family.
+- [ms-metabolomics](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/ms-metabolomics/1.0.0-dev/ms-metabolomics.yaml): Shared mass-spectrometry metabolomics layer.
+- [lc-ms-metabolomics](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/lc-ms-metabolomics/1.0.0-dev/lc-ms-metabolomics.yaml): LC-MS metabolomics specialization.
+- [gc-ms-metabolomics](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/gc-ms-metabolomics/1.0.0-dev/gc-ms-metabolomics.yaml): GC-MS metabolomics specialization.
+
+## Organism and sample-context templates
+
+- [human](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/human/1.1.0/human.yaml): Human-specific sample annotations.
+- [vertebrates](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/vertebrates/1.1.0/vertebrates.yaml): Non-human vertebrate sample annotations.
+- [invertebrates](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/invertebrates/1.1.0/invertebrates.yaml): Invertebrate sample annotations.
+- [plants](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/plants/1.1.0/plants.yaml): Plant-specific sample annotations.
+- [cell-lines](https://raw.githubusercontent.com/bigbio/sdrf-templates/dev/cell-lines/1.1.0/cell-lines.yaml): Cell line metadata built on top of the shared sample layer.
+
+## Related repositories
+
+- [proteomics-sample-metadata](https://github.com/bigbio/proteomics-sample-metadata): SDRF specification and end-user documentation.
+- [sdrf-pipelines](https://github.com/bigbio/sdrf-pipelines): Validation, parsing, and automation pipelines that consume these templates.


### PR DESCRIPTION
## Summary
- add GitHub Actions and license badges to the README
- refresh README wording around manifest generation and branching
- add a root `llms.txt` file with links to the manifest, schema, and key templates for LLM-assisted tooling

## Validation
- `git diff --check`
