### PR TITLE
Automate downstream sync PR dispatches

### DIFF
--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      templates_sha: ${{ steps.resolve-head.outputs.templates_sha }}
+      templates_ref: ${{ steps.resolve-head.outputs.templates_ref }}
 
     steps:
       - name: Checkout repository
@@ -49,3 +52,49 @@ jobs:
           git add templates.yaml
           git commit -m "chore: update templates.yaml manifest [skip ci]"
           git push
+
+      - name: Resolve latest templates HEAD
+        id: resolve-head
+        run: |
+          git fetch origin "${GITHUB_REF_NAME}"
+          echo "templates_sha=$(git rev-parse "origin/${GITHUB_REF_NAME}")" >> "$GITHUB_OUTPUT"
+          echo "templates_ref=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+  dispatch-downstream-sync:
+    name: Trigger downstream sync PRs
+    runs-on: ubuntu-latest
+    needs: generate
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Check downstream sync token
+        env:
+          DOWNSTREAM_SYNC_TOKEN: ${{ secrets.DOWNSTREAM_SYNC_TOKEN }}
+        run: |
+          if [ -z "${DOWNSTREAM_SYNC_TOKEN}" ]; then
+            echo "::error::Missing DOWNSTREAM_SYNC_TOKEN secret in sdrf-templates."
+            exit 1
+          fi
+
+      - name: Dispatch sync to sdrf-pipelines
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOWNSTREAM_SYNC_TOKEN }}
+          repository: bigbio/sdrf-pipelines
+          event-type: sync-sdrf-templates
+          client-payload: >-
+            {"templates_sha":"${{ needs.generate.outputs.templates_sha }}",
+             "templates_ref":"${{ needs.generate.outputs.templates_ref }}",
+             "source_repo":"${{ github.repository }}",
+             "source_run_id":"${{ github.run_id }}"}
+
+      - name: Dispatch sync to proteomics-sample-metadata
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOWNSTREAM_SYNC_TOKEN }}
+          repository: bigbio/proteomics-sample-metadata
+          event-type: sync-sdrf-templates
+          client-payload: >-
+            {"templates_sha":"${{ needs.generate.outputs.templates_sha }}",
+             "templates_ref":"${{ needs.generate.outputs.templates_ref }}",
+             "source_repo":"${{ github.repository }}",
+             "source_run_id":"${{ github.run_id }}"}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,33 @@ The `templates.yaml` manifest is auto-generated on merge to `main`. It contains:
 - Version history
 - Inheritance relationships (`extends`)
 
+## Downstream Synchronization
+
+After merges to `main`, the manifest workflow also dispatches sync events to the downstream
+consumer repositories:
+
+- [proteomics-metadata-standard](https://github.com/bigbio/proteomics-sample-metadata)
+- [sdrf-pipelines](https://github.com/bigbio/sdrf-pipelines)
+
+Those repositories listen for the dispatch event, update their vendored `sdrf-templates`
+submodule to the exact merged commit SHA, regenerate derived files if needed, and open or
+refresh a pull request automatically.
+
+### Required secret
+
+To enable the cross-repository dispatch, configure a secret named `DOWNSTREAM_SYNC_TOKEN` for
+this repository. An organization secret is a good fit because all repositories live under the
+same GitHub organization, but the workflow still needs an explicit token with access to the
+downstream repositories.
+
+Recommended scopes:
+
+- dispatch access to `bigbio/sdrf-pipelines`
+- dispatch access to `bigbio/proteomics-sample-metadata`
+
+The default `GITHUB_TOKEN` for `sdrf-templates` is repository-scoped, so it cannot be relied on
+to send cross-repository events by itself.
+
 ## Usage
 
 ### Finding the latest version


### PR DESCRIPTION
## Summary
- extend the manifest workflow to resolve the final `main` SHA after any manifest auto-commit
- dispatch `repository_dispatch` events to `bigbio/sdrf-pipelines` and `bigbio/proteomics-sample-metadata`
- fail clearly if the `DOWNSTREAM_SYNC_TOKEN` secret is not configured

## Notes
- this keeps `sdrf-templates` as the single source-of-truth trigger
- the downstream repos each open or refresh their own sync PR from the commit SHA included in the payload
- requires a cross-repo secret named `DOWNSTREAM_SYNC_TOKEN` with permission to dispatch events to the downstream repositories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation workflows for improved repository integration and deployment coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->