### PR TITLE
added new terms for metaproteomics, soil and water

### DIFF
--- a/metaproteomics/1.0.0/metaproteomics.yaml
+++ b/metaproteomics/1.0.0/metaproteomics.yaml
@@ -59,7 +59,7 @@ columns:
   - name: characteristics[sample name]
     ontology_accession: PRIDE:0000623
     description: Identifier of the sample, provided for backward compatibility with MIxS samp_name (MIXS:0001107). May be identical to `source name` (defined in base); use this column when preserving the original MIxS sample label is required.
-    requirement: optional
+    requirement: required
     allow_not_applicable: true
     allow_not_available: true
     validators:
@@ -73,25 +73,24 @@ columns:
             - Sample_1
             - Sample_2
 
-  - name: characteristics[environmental sample type]
-    ontology_accession: PRIDE:0000993
-    description: Type of environmental sample analyzed (ENVO or EFO term). Corresponds to MIxS env_medium (MIXS:0000014).
+  - name: characteristics[environmental medium]
+    ontology_accession: PRIDE:0000994
+    description: Environmental material from which the sample was obtained (ENVO term). Corresponds to MIxS env_medium (MIXS:0000014).
     requirement: required
-    allow_not_applicable: false
-    allow_not_available: false
+    allow_not_applicable: true
+    allow_not_available: true
     validators:
       - validator_name: ontology
         params:
           ontologies:
             - envo
-            - efo
-          error_level: warning
-          description: Should be a valid ENVO or EFO term
+          error_level: error
+          description: Should be a valid ENVO environmental material term
           examples:
             - soil
             - seawater
-            - gut microbiome
-            - wastewater
+            - freshwater
+            - feces
             - biofilm
 
   # ==========================================================================
@@ -131,26 +130,6 @@ columns:
             - Pacific Ocean
             - Amazon rainforest
             - 47.6062 N, 122.3321 W
-
-  - name: characteristics[environmental medium]
-    ontology_accession: PRIDE:0000994
-    description: Environmental material from which the sample was obtained (ENVO term). Corresponds to MIxS env_medium (MIXS:0000014).
-    requirement: recommended
-    allow_not_applicable: true
-    allow_not_available: true
-    validators:
-      - validator_name: ontology
-        params:
-          ontologies:
-            - envo
-          error_level: warning
-          description: Should be a valid ENVO environmental material term
-          examples:
-            - soil
-            - seawater
-            - freshwater
-            - feces
-            - biofilm
 
   # ==========================================================================
   # OPTIONAL COLUMNS - Environmental Context

--- a/soil/1.0.0/soil.yaml
+++ b/soil/1.0.0/soil.yaml
@@ -133,6 +133,23 @@ columns:
             - very poorly drained
           error_level: warning
           description: drainage classification
+          
+  - name: characteristics[soil type method]
+    ontology_accession: PRIDE:0001009
+    description: Method used to determine or classify soil type, including the classification system, field assessment protocol, or laboratory procedure applied (MIXS:0000334).
+    requirement: optional
+    allow_not_applicable: true
+    allow_not_available: true
+    validators:
+      - validator_name: pattern
+        params:
+          pattern: ^.+$
+          description: Description of the soil type determination or classification method
+          examples:
+            - USDA Soil Taxonomy classification
+            - WRB soil classification system
+            - Field assessment according to FAO Guidelines for Soil Description
+            - National Soil Resources Institute classification protocol      
 
   # ==========================================================================
   # OPTIONAL COLUMNS - Land Use & vegetation

--- a/water/1.0.0/water.yaml
+++ b/water/1.0.0/water.yaml
@@ -934,7 +934,6 @@ columns:
           pattern: ^.+$
           description: n-alkane concentration, composition, or distribution
           examples:
-            - C17: 12 mg/kg; C29: 45 mg/kg
             - C15-C35 n-alkane profile determined by GC-MS
             - Total n-alkanes 150 µg/g dry weight
 

--- a/water/1.0.0/water.yaml
+++ b/water/1.0.0/water.yaml
@@ -554,7 +554,7 @@ columns:
 
   - name: characteristics[calcium]
     ontology_accession: PRIDE:0000772
-    description: Calcium concentration. Corresponds to MIxS(MIXS:0000421).
+    description: Calcium concentration. Corresponds to MIxS:0000432.
     requirement: optional
     allow_not_applicable: true
     allow_not_available: true
@@ -570,7 +570,7 @@ columns:
 
   - name: characteristics[magnesium]
     ontology_accession: PRIDE:0000793
-    description: Magnesium concentration. Corresponds to MIxS(MIXS:0000431).
+    description: Magnesium concentration. Corresponds to MIxS:0000431.
     requirement: optional
     allow_not_applicable: true
     allow_not_available: true
@@ -765,7 +765,7 @@ columns:
 
   - name: characteristics[dissolved hydrogen]
     ontology_accession: PRIDE:0000780
-    description: Dissolved hydrogen concentration. Corresponds to MIxS (MIXS:0000205).
+    description: Dissolved hydrogen concentration. Corresponds to MIxS (MIXS:0000179).
     requirement: optional
     allow_not_applicable: true
     allow_not_available: true
@@ -921,6 +921,22 @@ columns:
           examples:
             - 0.5 mg/L
             - 1 mg/L
+
+  - name: characteristics[n-alkanes]
+    ontology_accession: MIXS:0000503
+    description: Concentration or composition of n-alkanes present in the sample. n-Alkanes are straight-chain saturated hydrocarbons that can be used as indicators of organic matter sources and environmental conditions.
+    requirement: optional
+    allow_not_applicable: true
+    allow_not_available: true
+    validators:
+      - validator_name: pattern
+        params:
+          pattern: ^.+$
+          description: n-alkane concentration, composition, or distribution
+          examples:
+            - C17: 12 mg/kg; C29: 45 mg/kg
+            - C15-C35 n-alkane profile determined by GC-MS
+            - Total n-alkanes 150 µg/g dry weight
 
   # ==========================================================================
   # OPTIONAL COLUMNS - Biological Activity


### PR DESCRIPTION
#47 made the changes @ypriverol 
added missing terms for soil and water.
@tivdnbos didn't add env_broad_scale	MIXS:0000012
env_local_scale	MIXS:0000013 as it needs to be added to ontology first and I did a PR and will add soon
alt	MIXS:0000094 lat_lon	MIXS:0000009 are there in the metaproteomics template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional soil type method field with description validation.
  * Added optional n-alkanes field for tracking aquatic concentrations.

* **Updates**
  * Sample name now required in metaproteomics submissions.
  * Environmental medium reclassified as required with stricter validation in metaproteomics.
  * Corrected cross-reference mappings for mineral/chemical fields in water template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->