### PR TITLE
feat(base): wire column_name_validator into the base schema

### DIFF
--- a/base/1.1.0/base.yaml
+++ b/base/1.1.0/base.yaml
@@ -30,6 +30,8 @@ usable_alone: false
 validators:
   - validator_name: trailing_whitespace_validator
     params: {}
+  - validator_name: column_name_validator
+    params: {}
   - validator_name: column_order
     params: {}
   - validator_name: empty_cells

--- a/sdrf-template.schema.json
+++ b/sdrf-template.schema.json
@@ -139,6 +139,7 @@
           "type": "string",
           "enum": [
             "trailing_whitespace_validator",
+            "column_name_validator",
             "column_order",
             "empty_cells",
             "combination_of_columns_no_duplicate_validator",


### PR DESCRIPTION
## What

Declares the new `column_name_validator` as a global validator in the base schema (`base/1.1.0/base.yaml`), so every template inherits it. It flags column names that carry whitespace around the brackets, for example `characteristics [organism]` (space before the bracket) or `comment[modification parameters ]` (space inside the brackets).

## Why

SDRF column names are space-sensitive, so `characteristics [organism]` and `comment[modification parameters ]` are treated as *different*, unrecognised columns. Their data is silently ignored downstream while the file still passes validation, which makes the defect invisible today.

## Real-world examples this would catch

Malformed headers already present in the corpus, cleaned up in bigbio/sdrf-annotated-datasets#32, for example:

* `comment[modification parameters ]` (space before the closing bracket)
* space-before-bracket variants such as `characteristics [organism]`

Those files validate cleanly today; with this validator wired in, they are flagged.

## Companion PR and merge order

The validator itself is implemented in `sdrf-pipelines` (companion PR: bigbio/sdrf-pipelines#310). Merge this templates PR first, then bump the `sdrf-templates` submodule in the `sdrf-pipelines` PR to its merge commit to activate the check in CI.
